### PR TITLE
Added flask_socket and flask_cors to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 nostr_sdk==0.34.0
 cryptography==41.0.7
 brotli==1.1.0
+flask_socketio==5.5.1
+flask_cors==5.0.0


### PR DESCRIPTION
I needed to add flask_socket and flaskcors modules via pip before I could finish building the frontend on Fedora 41 using a Python3.11 environment.